### PR TITLE
watch, build: generate TS sourcemaps for easier debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 bower_components
 typings
 build
+dist
 node_modules
 *.js
+*.js.map
 *.log

--- a/README.md
+++ b/README.md
@@ -2,31 +2,23 @@
 
 It's a starship bridge simulator.
 
-## Install Dependencies
-```
-npm -g install bower typescript typings http-server
-npm install
-bower install
-typings install
-```
+## Install/Update Dependencies
+Node.JS and NPM are required.
 
-## Update Dependencies
-```
-npm -g update
-npm update
-bower update
+```sh
+rpm run deps
 ```
 
 ## Developing
 ### Build TypeScript
 This command compiles all `.ts` files in the project and will recompile if
 there are any changes made to them.
-```
+```sh
 npm run watch
 ```
 
 ### Run
-```
+```sh
 http-server
 google-chrome http://localhost:8080/
 ```
@@ -53,12 +45,12 @@ http://localhost:8080/?station=weapons&metrics#host
 
 ### Test
 Run all tests (includes compilation).
-```
+```sh
 npm run test
 ```
 
 Run all tests (includes compilation) and watch for changes.
-```
+```sh
 npm run watch-test
 ```
 
@@ -66,7 +58,7 @@ npm run watch-test
 To build the production version of the app run the build script. This
 automatically compiles the typescript, vulcanizes and minifies the source code.
 Output goes into `build/`.
-```
+```sh
 node ./build.js
 ```
 

--- a/client/asset-pack.ts
+++ b/client/asset-pack.ts
@@ -21,8 +21,9 @@ export class AssetPack extends polymer.Base {
 
   private modelPromises: {[model: string]: Promise<BABYLON.Mesh>} = {};
 
-  @computed()
-  baseURL(manifest: string): string { return this.urlDir(manifest); }
+  @property({computed: 'computeBaseUrl(manifest)'})
+  baseURL: string
+  computeBaseURL(manifest: string): string { return this.urlDir(manifest); }
 
   @property({type: Object, computed: 'computeShips(manifestBody)'})
   ships: Ship[];

--- a/client/game.html
+++ b/client/game.html
@@ -316,5 +316,4 @@
     </paper-dialog>
 
   </template>
-  <script src="../out.js"></script>
 </dom-module>

--- a/client/game.ts
+++ b/client/game.ts
@@ -118,13 +118,15 @@ class Game extends polymer.Base {
     }
   }
 
-  @computed()
-  showWelcome(connecting: boolean, connected: boolean): boolean {
+  @property({computed: 'computeShowWelcome(connecting, connected)'})
+  showWelcome: boolean;
+  computeShowWelcome(connecting: boolean, connected: boolean): boolean {
     return !connecting && !connected;
   }
 
-  @computed()
-  showStations(connected: boolean, gameOver: boolean): boolean {
+  @property({computed: 'computeShowStations(connected, gameOver)'})
+  showStations: boolean;
+  computeShowStations(connected: boolean, gameOver: boolean): boolean {
     return connected && !gameOver;
   }
 
@@ -150,9 +152,7 @@ class Game extends polymer.Base {
   }
 
   @observe('station')
-  stationChanged(station: string) {
-    this.stations = {[station]: true};
-  }
+  stationChanged(station: string) { this.stations = {[station]: true}; }
 
   openSettingsDialog(): void { this.$.settingsDialog.open(); }
 
@@ -246,24 +246,16 @@ class Game extends polymer.Base {
   }
 
   @listen('fire-laser')
-  fireLaser(ev: any) {
-    this.$.input.commands.fireLaser = ev.detail.heading;
-  }
+  fireLaser(ev: any) { this.$.input.commands.fireLaser = ev.detail.heading; }
 
   @listen('start-left-turn')
-  startLeftTurn() {
-    this.$.input.startLeftTurn();
-  }
+  startLeftTurn() { this.$.input.startLeftTurn(); }
 
   @listen('start-right-turn')
-  startRightTurn() {
-    this.$.input.startRightTurn();
-  }
+  startRightTurn() { this.$.input.startRightTurn(); }
 
   @listen('stop-turn')
-  stopTurn() {
-    this.$.input.stopTurn();
-  }
+  stopTurn() { this.$.input.stopTurn(); }
 
   notifyChanges(update: Update): void {
     // Notify Polymer of changes in components for which elements may be

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <title>Bridgesim</title>
-    <link rel="shortcut icon" href="favicon.png">
+    <link rel="shortcut icon" type="image/png" href="favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono" rel="stylesheet" type="text/css">
     <style>
       body {
@@ -21,5 +21,6 @@
   </head>
   <body>
     <bridgesim-game></bridgesim-game>
+    <script src="./out.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
   },
   "scripts": {
     "test": "tsc && mocha $(find . -name '*_test.js' ! -path './node_modules/*' ! -path './bower_components/*'| tr -s '\n' ' ')",
-    "watch": "tsc --watch & watchify $(find client/ -name '*.js' ! -name '*_test.js' | tr -s '\n' ' ') --outfile out.js --debug --verbose",
+    "watch": "watchify $(find client/ -name '*.ts' ! -name '*_test.ts' | tr -s '\n' ' ') -p tsify --outfile out.js --debug --verbose",
     "watch-test": "tsc --watch & mocha $(find . -name '*_test.js' ! -path './node_modules/*' ! -path './bower_components/*'| tr -s '\n' ' ') --watch",
     "clean": "rm -rf build && find . -name '*.js' ! -path './util/build.js' ! -path './node_modules/*' ! -path './bower_components/*' | xargs rm",
-    "build": "node ./util/build.js"
+    "build": "node ./util/build.js",
+    "deps": "npm -g install bower typescript typings http-server && npm install && bower install && typings install && npm -g update && npm update && bower update"
   },
   "repository": {
     "type": "git",
@@ -32,7 +33,13 @@
   },
   "homepage": "https://github.com/aomarks/bridgesim#readme",
   "dependencies": {
+    "minifyify": "^7.3.3",
+    "source-map-concat": "^1.0.1",
+    "source-map-dummy": "^1.0.0",
+    "source-map-resolve": "^0.5.0",
     "svgo": "^0.6.6",
-    "typescript-collections": "^1.1.2"
+    "tsify": "^1.0.3",
+    "typescript-collections": "^1.1.2",
+    "uglify-js": "^2.7.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,12 @@
     "module": "commonjs",
     "experimentalDecorators": true,
     "noImplicitReturns": true,
-    "pretty": true
+    "pretty": true,
+    "sourceMap": true
   },
   "exclude": [
     "bower_components",
+    "node_modules",
     "typings"
   ]
 }


### PR DESCRIPTION
Sorry for the grab bag of build related improvements.
- Adds `npm run deps` which installs & updates all dependencies.
- Correctly generate TS sourcemaps for build/watch.
- Remove occurrences of `@computed()` shorthand which breaks during minification.
- Some random clang formatting stuff.
- Minor readme tweaks.
